### PR TITLE
GHC-43: Upgrading to appointments-1.2-SNAPSHOT.omod

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <initializerVersion>1.2.0-SNAPSHOT</initializerVersion>
 
     <!-- Bahmni modules -->
-    <appointmentsVersion>1.1-SNAPSHOT</appointmentsVersion>
+    <appointmentsVersion>1.2-SNAPSHOT</appointmentsVersion>
     <atomfeedVersion>2.5.6</atomfeedVersion>
     <bacteriologyVersion>1.1</bacteriologyVersion>
     <bahmnicoreVersion>0.92-SNAPSHOT</bahmnicoreVersion>


### PR DESCRIPTION
iniz depends on appointments-1.2-SNAPSHOT, so the distro should also install this version of appointments module